### PR TITLE
Updates for recursive-delete option

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -90,6 +90,12 @@ class Module extends \yii\base\Module
     public $repair = true;
 
     /**
+     * Active / deactivate the filesystem recursive folder delete
+     * @var bool
+     */
+    public $deleteRecursive = false;
+
+    /**
      * Used as default permissions on active \hrzg\filefly\plugins\RepairKit
      * if $this->repair = true
      *

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ i.e. `AFM_FILESYSTEM=fsLocal`
     'filesystem'         => getenv('AFM_FILESYSTEM'),
     'slugNames'			 => (getenv('AFM_SLUG_NAMES')) ? getenv('AFM_SLUG_NAMES') : true,
     'repair'             => (getenv('AFM_REPAIR')) ? getenv('AFM_REPAIR') : true,
+    'deleteRecursive'    => (getenv('AFM_DELETE_RECURSIVE')) ? getenv('AFM_DELETE_RECURSIVE') : false,
     'defaultPermissions' => [
         \hrzg\filefly\Module::ACCESS_OWNER  => 1,
         \hrzg\filefly\Module::ACCESS_READ   => \hrzg\filefly\models\FileflyHashmap::$_all,

--- a/components/FileManagerApi.php
+++ b/components/FileManagerApi.php
@@ -20,7 +20,6 @@ use hrzg\filefly\plugins\SetAccess;
 use hrzg\filefly\plugins\UpdatePermission;
 use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException;
-use League\Flysystem\Util;
 use yii\base\Component;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Inflector;
@@ -794,8 +793,7 @@ Html;
             }
 
             if ($this->_filesystem->get($path)->isDir()) {
-                $allowDeleteRecursive = getenv('AFM_DELETE_RECURSIVE') ? (boolean)getenv('AFM_DELETE_RECURSIVE') : false;
-                if (!$allowDeleteRecursive && $this->_filesystem->isEmpty($path) === false) {
+                if (!$this->_module->deleteRecursive && $this->_filesystem->isEmpty($path) === false) {
                     return 'notempty';
                 }
 
@@ -809,7 +807,7 @@ Html;
             }
 
             // remove permission
-            $removedPermission = $this->_filesystem->removeAccess($path);
+            $removedPermission = $this->_filesystem->removeAccess($path, true);
             if ($removedPermission === false) {
                 return 'errorpermission';
             }

--- a/plugins/RemoveAccess.php
+++ b/plugins/RemoveAccess.php
@@ -10,7 +10,6 @@
 namespace hrzg\filefly\plugins;
 
 use hrzg\filefly\models\FileflyHashmap;
-use League\Flysystem\PluginInterface;
 
 /**
  * Class RemoveAccess
@@ -31,26 +30,47 @@ class RemoveAccess extends AccessPlugin
      * The full path strings of the file or directory to be removed
      *
      * @param string $itemPath
+     * @param bool $recursive
      *
      * @return bool
      */
-    public function handle($itemPath = null)
+    public function handle($itemPath = null, $recursive = false)
     {
+        // remove all hashmap entries beneath $itemPath
+        if ($recursive) {
+            $items = FileflyHashmap::find()
+                ->andWhere(['component' => $this->component])
+                ->andWhere(['like', 'path', $itemPath . '/%', false])
+                ->all();
 
+            if (empty($items)) {
+                \Yii::info('Could not find items beneath [' . $itemPath . '] in hash table!', __METHOD__);
+            } else {
+                foreach ($items as $item) {
+                    /** @var $item FileflyHashmap */
+                    if (!$item->delete()) {
+                        \Yii::error('Could not delete item [' . $item->path . '] in hash table!', __METHOD__);
+                        return false;
+                    }
+                }
+            }
+        }
+
+        /** @var $item FileflyHashmap */
         $item = FileflyHashmap::find()
             ->andWhere(['component' => $this->component])
             ->andWhere(['path' => $itemPath])
             ->one();
 
-        if ($item === null) {
+        if (empty($item)) {
             \Yii::error('Could not find item [' . $itemPath . '] in hash table!', __METHOD__);
             return false;
+        } else {
+            if (!$item->delete()) {
+                \Yii::error('Could not delete item [' . $item->path . '] in hash table!', __METHOD__);
+                return false;
+            }
         }
-        if (!$item->delete()) {
-            \Yii::error('Could not delete item [' . $itemPath . '] in hash table!', __METHOD__);
-            return false;
-        }
-
         return true;
     }
 }


### PR DESCRIPTION
The `removeAccess plugin` was not ready for a recursive folder delete option. Before these changes after you deleted a folder with `AFM_DELETE_RECURSIVE=1` the files will be all deleted.
But in the hashmap table only the entry for the deleted folders has been removed, not all the entries beneath.

And I have introduces the module property `deleteRecursive` which is more consistent to the other provided options like `repair` and `slugNames`.

Set `deleteRecursive`default to `false`for bc.