### PR TITLE
optimize memory usage and bugfix

### DIFF
--- a/components/FileManagerApi.php
+++ b/components/FileManagerApi.php
@@ -553,9 +553,8 @@ Html;
             header('Pragma: public');
 
             $stream = $this->_filesystem->readStream($path);
-            echo stream_get_contents($stream);
+            fpassthru($stream);
             fclose($stream);
-
 
         } catch (FileNotFoundException $e) {
             return false;
@@ -595,7 +594,7 @@ Html;
             header('Pragma: public');
 
             $stream = $this->_filesystem->readStream($path);
-            echo stream_get_contents($stream);
+            fpassthru($stream);
             fclose($stream);
 
         } catch (FileNotFoundException $e) {

--- a/components/FileManagerApi.php
+++ b/components/FileManagerApi.php
@@ -489,10 +489,15 @@ Html;
             foreach ($files as $file) {
                 $stream   = fopen($file['tmp_name'], 'r+');
 
-                // parse $file['name'] for slugging, im enabled
+                // parse $file['name'] for slugging if enabled
                 if ($this->_module->slugNames) {
                     $pathInfo = pathinfo($file['name']);
-                    $fullPath = $path.'/'.Inflector::slug($pathInfo['filename']).'.'.strtolower($pathInfo['extension']);
+                    // check if filename has extension
+                    if(empty($pathInfo['extension'])) {
+                        $fullPath = $path . '/' . Inflector::slug($pathInfo['filename']);
+                    } else {
+                        $fullPath = $path . '/' . Inflector::slug($pathInfo['filename']) . '.' . strtolower($pathInfo['extension']);
+                    }
                 } else {
                     $fullPath = $path.'/'.$file['name'];
                 }


### PR DESCRIPTION
- d5a45ed0f67b6250fc4a037b7160b3c57ac83e09: Fixed memory usage while streaming/downloading file: use fpassthru() to write the stream directly to the output buffer instead of copy the whole filecontent to memory (required by echo)
- bc87121bd0f389d01962b39c6eb49498b70e166e: Fixed a bug when uploaded file has no extension