### PR TITLE
Fixed undefined variable in upload action

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -349,9 +349,10 @@ class ApiController extends WebController
                     $fullPath = $path . trim($file['name'], '/');
                 }
 
+                $uploaded = false;
                 try {
                     $mimeTypes = \Yii::$app->settings->get('mime-whitelist', 'filefly');
-                    empty($mimeTypes) ? $acceptedMimeTypes = [] : $acceptedMimeTypes = explode(",", $mimeTypes);
+                    $acceptedMimeTypes = empty($mimeTypes) ? [] : explode(",", $mimeTypes);
 
                     if( in_array(mime_content_type($file['tmp_name']), $acceptedMimeTypes, false) || empty($acceptedMimeTypes)){
                         $uploaded = $fileSystem->writeStream(


### PR DESCRIPTION
I fixed an error that occurred when mime-types was defined and an attempt was made to upload a file format that was not allowed. 