### PR TITLE
add optional urlCallback module property

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -144,6 +144,17 @@ class Module extends \yii\base\Module
     */
     public $thumbnailCallback;
 
+
+    /**
+     * optional callback that can define a list of urls that will be displayed in filemanager
+     * backend in the item 'copy urls' overlay.
+     *
+     * Return value of the callback has to be an array!
+     *
+     * @var null|callable
+     */
+    public $urlCallback;
+
     /**
      * @inheritdoc
      *

--- a/README.md
+++ b/README.md
@@ -39,7 +39,22 @@ i.e. `AFM_FILESYSTEM=fsLocal`
         \hrzg\filefly\Module::ACCESS_READ   => \hrzg\filefly\models\FileflyHashmap::$_all,
         \hrzg\filefly\Module::ACCESS_UPDATE => \hrzg\filefly\models\FileflyHashmap::$_all,
         \hrzg\filefly\Module::ACCESS_DELETE => \hrzg\filefly\models\FileflyHashmap::$_all,
-    ]
+    ],
+    # the urlCallbck property can be used to provide customized urls for each file item which (if defined) will overrite 
+    # the default handler URLs
+    'urlCallback'        => function($item) {
+                $urls = [];
+                $isImageFileExtList = ['jpg', 'jpeg', 'gif', 'tiff', 'tif', 'svg', 'png', 'bmp'] ;
+                if ($item['type'] === 'file') {
+                    if (in_array(strtolower($item['extension']), $isImageFileExtList)) {
+                        $urls['image url'] = \dmstr\willnorrisImageproxy\Url::image($item['path']);
+                    }
+                    else {
+                        $urls['download url'] = implode('/', ['/img/download', ltrim($item['path'], '/')]) . ',p1';
+                    }
+                }
+                return $urls;
+            },
 ],
 ```
 

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -479,8 +479,15 @@ class ApiController extends WebController
                         $thumbnail = '';
                     }
 
+                    $itemUrls = [];
+                    if (is_callable($this->module->urlCallback)) {
+                        $itemUrls = call_user_func($this->module->urlCallback, $item);
+                    }
+
                     $files[] = [
                         'name' => $item['basename'],
+                        'path' => $item['path'],
+                        'urls' => $itemUrls,
                         'thumbnail' => $thumbnail,
                         'size' => $size,
                         'date' => date('Y-m-d H:i:s', $time),


### PR DESCRIPTION
The new (optional)  urlCallback module property can be used to define a list of urls that will be displayed in filemanager angular app  in the item 'copy urls' overlay.

This is the counterpart to the `item.model.urls` addition in https://github.com/dmstr/yii2-filemanager-widgets/pull/16
