### PR TITLE
Feature/preview callback

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -156,6 +156,14 @@ class Module extends \yii\base\Module
     public $urlCallback;
 
     /**
+     * optional callback that can define the preview URL for an item
+     * if not set the default filemanager downloadURL will be used
+     *
+     * @var
+     */
+    public $previewCallback;
+
+    /**
      * @inheritdoc
      *
      * @throws HttpException

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ i.e. `AFM_FILESYSTEM=fsLocal`
 
 #### Yii config
 
-```
+```php
 'filefly' => [
     'class'              => 'hrzg\filefly\Module',
     'layout'             => '@backend/views/layouts/main',
@@ -40,21 +40,31 @@ i.e. `AFM_FILESYSTEM=fsLocal`
         \hrzg\filefly\Module::ACCESS_UPDATE => \hrzg\filefly\models\FileflyHashmap::$_all,
         \hrzg\filefly\Module::ACCESS_DELETE => \hrzg\filefly\models\FileflyHashmap::$_all,
     ],
-    # the urlCallbck property can be used to provide customized urls for each file item which (if defined) will overrite 
+    # the urlCallbck property can be used to provide customized urls for each file item which (if defined) will overwrite 
     # the default handler URLs
     'urlCallback'        => function($item) {
-                $urls = [];
-                $isImageFileExtList = ['jpg', 'jpeg', 'gif', 'tiff', 'tif', 'svg', 'png', 'bmp'] ;
-                if ($item['type'] === 'file') {
-                    if (in_array(strtolower($item['extension']), $isImageFileExtList)) {
-                        $urls['image url'] = \dmstr\willnorrisImageproxy\Url::image($item['path']);
-                    }
-                    else {
-                        $urls['download url'] = implode('/', ['/img/download', ltrim($item['path'], '/')]) . ',p1';
-                    }
-                }
-                return $urls;
-            },
+		$urls = [];
+		$isImageFileExtList = ['jpg', 'jpeg', 'gif', 'tiff', 'tif', 'svg', 'png', 'bmp'] ;
+		if ($item['type'] === 'file') {
+			if (in_array(strtolower($item['extension']), $isImageFileExtList)) {
+				$urls['image url'] = \dmstr\willnorrisImageproxy\Url::image($item['path']);
+			}
+			else {
+				$urls['download url'] = implode('/', ['/img/download', ltrim($item['path'], '/')]) . ',p1';
+			}
+		}
+		return $urls;
+	},
+	// previewCallback can be used to overwrite the default downloadUrl for preview URLs within filemanagerApp
+	'previewCallback' => function($item) {
+		$isImageFileExtList = ['jpg', 'jpeg', 'gif', 'tiff', 'tif', 'png', 'bmp'] ;
+		if ($item['type'] === 'file') {
+			if (in_array(strtolower($item['extension']), $isImageFileExtList)) {
+				return \dmstr\willnorrisImageproxy\Url::image($item['path'], '500x');
+			}
+		}
+		return '';
+	}
 ],
 ```
 

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -473,10 +473,9 @@ class ApiController extends WebController
                         $time = $fileSystem->getTimestamp($item['path']) ?: time();
                     }
 
+                    $thumbnail = '';
                     if (is_callable($this->module->thumbnailCallback)) {
                         $thumbnail = call_user_func($this->module->thumbnailCallback, $item);
-                    } else {
-                        $thumbnail = '';
                     }
 
                     $itemUrls = [];

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -483,15 +483,22 @@ class ApiController extends WebController
                     if (is_callable($this->module->urlCallback)) {
                         $itemUrls = call_user_func($this->module->urlCallback, $item);
                     }
+                    $previewUrl = '';
+                    if (is_callable($this->module->previewCallback)) {
+                        $previewUrl = call_user_func($this->module->previewCallback, $item);
+                    }
 
                     $files[] = [
                         'name' => $item['basename'],
+                        'dirname' => $item['dirname'],
                         'path' => $item['path'],
                         'urls' => $itemUrls,
                         'thumbnail' => $thumbnail,
+                        'preview' => $previewUrl,
                         'size' => $size,
                         'date' => date('Y-m-d H:i:s', $time),
                         'type' => $item['type'],
+                        'extension' => $item['extension'] ?? ''
                     ];
                 }
             }


### PR DESCRIPTION
this PR adds new optional previewUrl callback to be able to define/overwrite the url used for the file previews within filemanagerApp. 
works more or less like the thumbnail callback property.

will be used in new [filemanger-widget](https://github.com/dmstr/yii2-filemanager-widgets) version (at work).