### PR TITLE
Feature/filemanager widget options

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -144,7 +144,6 @@ class Module extends \yii\base\Module
     */
     public $thumbnailCallback;
 
-
     /**
      * optional callback that can define a list of urls that will be displayed in filemanager
      * backend in the item 'copy urls' overlay.
@@ -162,6 +161,14 @@ class Module extends \yii\base\Module
      * @var
      */
     public $previewCallback;
+
+    /**
+     * additional options for the angular fileManagerApp
+     * @see: dmstr/yii2-filemanager-widgets
+     *
+     * @var array
+     */
+    public $fileManagerWidgetOptions = [];
 
     /**
      * @inheritdoc

--- a/README.md
+++ b/README.md
@@ -162,6 +162,31 @@ see https://github.com/dmstr/yii2-filemanager-widgets
     ) }}
 ```
 
+Options for the yii2-filemanager-widgets Widget can be injected via the Module property `fileManagerWidgetOptions`
+
+example:
+```php
+
+        'filefly' => [
+            'filesystemComponents' => [
+                'ftp' => 'fsFtp',
+                'ftpcrud' => 'fsFtpCrud',
+            ],
+            // ...
+            // other configs
+            // ...
+            // Options for the angular fileManagerWidget
+            'fileManagerWidgetOptions' => [
+                'searchForm' => false,
+                'allowedActions' => [
+                    'move' => false,
+                    'upload' => false,
+                    'createFolder' => false,
+                    ],
+            ],
+        ],
+```        
+
 ### Controller action in iFrame
 
 Modal button

--- a/views/default/filemanager.php
+++ b/views/default/filemanager.php
@@ -14,14 +14,16 @@ if (class_exists(\hrzg\filemanager\widgets\FileManagerWidget::class)) {
         $enableIconPreviewView = false;
     }
 
+    $filemanagerWidgetConfig = [
+        'handlerUrl' => Url::to('/' . $this->context->module->id . '/api'),
+        'enableThumbnails' =>  $enableThumbnails,
+        'enableIconPreviewView' => $enableIconPreviewView,
+        'options' => !empty($this->context->module->fileManagerWidgetOptions) ? $this->context->module->fileManagerWidgetOptions : [],
+    ];
+
     echo \hrzg\filemanager\widgets\FileManagerWidget::widget(
-        [
-            'handlerUrl' => Url::to('/' . $this->context->module->id . '/api'),
-            'enableThumbnails' =>  $enableThumbnails,
-            'enableIconPreviewView' => $enableIconPreviewView,
-        ]
+        $filemanagerWidgetConfig
     );
 } else {
     echo Html::tag('p', Yii::t('filefly', 'Filemanager widgets are not available.'));
 }
-

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * @var yii\web\View $this
  */
 
@@ -9,28 +9,16 @@ use yii\helpers\Inflector;
 $this->title = 'Filefly';
 ?>
 
-<?php $url = \yii\helpers\Url::to($this->context->module->id . '/api', true) ?>
-<?php $relativeUrl = '/' . \yii\helpers\Url::to($this->context->module->id . '/api', false) ?>
-
 <h1><?= Inflector::titleize($this->context->module->id) ?></h1>
 
-<?php if (class_exists(\hrzg\filemanager\widgets\FileManagerWidget::class)): ?>
-
-    <div class="box">
-        <?= \hrzg\filemanager\widgets\FileManagerWidget::widget(
-            ['handlerUrl' => \yii\helpers\Url::to('/' . $this->context->module->id . '/api')]
-        ) ?>
-    </div>
-
-<?php else : ?>
-
-    <div class="callout callout-warning">
-        Filemanager widgets are not available.
-    </div>
-
-<?php endif; ?>
+<?php
+echo $this->render('filemanager');
+?>
 
 <?php if (Yii::$app->user->can(Module::ACCESS_ROLE_ADMIN)): ?>
+
+    <?php $url = \yii\helpers\Url::to($this->context->module->id . '/api', true) ?>
+    <?php $relativeUrl = '/' . \yii\helpers\Url::to($this->context->module->id . '/api', false) ?>
 
     <div class="row">
         <div class="col-xs-12 col-md-6">


### PR DESCRIPTION
This PR adds a new (optional) module property `fileManagerWidgetOptions` which can be used to set/inject options for the fileManagerWidget introduced in https://github.com/dmstr/yii2-filemanager-widgets/pull/18