### PR TITLE
Access check

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -177,7 +177,9 @@ class Module extends \yii\base\Module
      */
     public function beforeAction($action)
     {
-        parent::beforeAction($action);
+        if (!parent::beforeAction($action)) {
+            return false;
+        }
 
         if (empty($this->filesystem)) {
             \Yii::$app->session->addFlash(


### PR DESCRIPTION
parent's return value must be checked so we can ensure, that the current user is allowed to access the action or module in general.